### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### 1.2.0 (2016-12-21)
 
-* Import `V1.FLOW` from `mirage-types` into `Mirage_flow.S` (@samoht)
-* Import `V1_LWT.FLOW` from `mirage-types-lwt` into `Mirage_flow_lwt.S` (@samoht)
+* Import `Mirage_types.FLOW` from `mirage-types` into `Mirage_flow.S` (@samoht)
+* Import `Mirage_types_lwt.FLOW` from `mirage-types-lwt` into `Mirage_flow_lwt.S` (@samoht)
 * Rename the existing `Mirage_flow` into `Mirage_flow_lwt` (@samoht)
 * Rename `Lwt_io_flow` into `Mirage_flow_unix` (@samoht)
 


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.