### PR TITLE
Packaging cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,13 @@
-
 .PHONY: build clean test
 
 build:
-	jbuilder build @install
+	jbuilder build --dev
 
 test:
-	jbuilder runtest
-
-install:
-	jbuilder install
-
-uninstall:
-	jbuilder uninstall
+	jbuilder runtest --dev
 
 clean:
-	rm -rf _build
+	jbuilder clean
 
 REPO=../../mirage/opam-repository
 PACKAGES=$(REPO)/packages
@@ -28,5 +21,3 @@ pkg-%:
 PKGS=$(basename $(wildcard *.opam))
 opam-pkg:
 	$(MAKE) $(PKGS:%=pkg-%)
-
-

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,7 +1,7 @@
+(jbuild_version 1)
+
 (library
  ((name        mirage_flow_lwt)
   (public_name mirage-flow-lwt)
   (libraries   (lwt cstruct mirage-flow mirage-clock))
-  (flags       (:standard -w "A-4-41-44" -warn-error "+1..49-34" -safe-string))
-  (wrapped     false)
-))
+  (wrapped     false)))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,7 +1,7 @@
+(jbuild_version 1)
+
 (library
  ((name        mirage_flow)
   (public_name mirage-flow)
   (libraries   (fmt result))
-  (flags       (:standard -w "A-4-41-44" -warn-error "+1..49-34" -safe-string))
-  (wrapped     false)
-))
+  (wrapped     false)))

--- a/src/mirage_flow.ml
+++ b/src/mirage_flow.ml
@@ -44,6 +44,7 @@ module type ABSTRACT = sig
 end
 
 module type S = ABSTRACT with type write_error = private [> write_error]
+  [@@ocaml.warning "-34"]
 
 module type CONCRETE = ABSTRACT
   with type error = [`Msg of string]

--- a/src/mirage_flow.mli
+++ b/src/mirage_flow.mli
@@ -113,6 +113,7 @@ end
     type. Note: ideally [error] should be the empty row, but not easy
     way to express this in OCaml. *)
 module type S = ABSTRACT with type write_error = private [> write_error ]
+  [@@ocaml.warning "-34"]
 
 (** [CONCRETE] expose the private row as [`Msg str] errors, using
     [pp_error] and [pp_write_error]. *)

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,8 +1,10 @@
+(jbuild_version 1)
+
 (executables
  ((names (test))
-  (libraries (mirage-flow-unix alcotest))
-))
+  (libraries (mirage-flow-unix alcotest))))
+
 (alias
  ((name    runtest)
   (deps    (test.exe))
-  (action  (run ${<} -e -v))))
+  (action  (run ${<} --color=always))))

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -1,7 +1,7 @@
+(jbuild_version 1)
+
 (library
  ((name        mirage_flow_unix)
   (public_name mirage-flow-unix)
   (libraries   (mirage-flow-lwt lwt.unix))
-  (flags       (:standard -w "A-4-41-44" -warn-error "+1..49-34" -safe-string))
-  (wrapped     false)
-))
+  (wrapped     false)))


### PR DESCRIPTION
- add jbuild_version to jbuild files
- build with standard flags
- build dev versions with --dev to catch up warnings