### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-flow-lwt.opam
+++ b/mirage-flow-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "fmt"
   "lwt"
   "logs"

--- a/mirage-flow-unix.opam
+++ b/mirage-flow-unix.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "fmt"
   "logs"
   "mirage-flow" {>= "1.2.0"}

--- a/mirage-flow.opam
+++ b/mirage-flow.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "fmt"
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.