### PR TITLE
remove mirage-flow-lwt, put combinators into mirage-flow-combinators; specialise mirage-flow to Lwt.t and Cstruct.t directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,15 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="mirage-flow:. mirage-flow-lwt:. mirage-flow-unix:."
+    - PINS="mirage-flow.2.0.0:. mirage-flow-combinators.2.0.0:. mirage-flow-unix:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
   matrix:
-  - OCAML_VERSION=4.04 PACKAGE="mirage-flow-lwt"
-  - OCAML_VERSION=4.04 PACKAGE="mirage-flow-unix"
-  - OCAML_VERSION=4.05 PACKAGE="mirage-flow-lwt"
-  - OCAML_VERSION=4.05 PACKAGE="mirage-flow-unix"
-  - OCAML_VERSION=4.06 PACKAGE="mirage-flow-lwt"
+  - OCAML_VERSION=4.06 PACKAGE="mirage-flow-combinators"
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-unix"
-  - OCAML_VERSION=4.07 PACKAGE="mirage-flow"
-  - OCAML_VERSION=4.07 PACKAGE="mirage-flow-lwt"
+  - OCAML_VERSION=4.07 PACKAGE="mirage-flow-combinators"
   - OCAML_VERSION=4.07 PACKAGE="mirage-flow-unix"
+  - OCAML_VERSION=4.08 PACKAGE="mirage-flow"
+  - OCAML_VERSION=4.08 PACKAGE="mirage-flow-combinators"
+  - OCAML_VERSION=4.08 PACKAGE="mirage-flow-unix"
+  - OCAML_VERSION=4.09 PACKAGE="mirage-flow"
+  - OCAML_VERSION=4.09 PACKAGE="mirage-flow-combinators"
+  - OCAML_VERSION=4.09 PACKAGE="mirage-flow-unix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: c
-sudo: required
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: false
+services:
+  - docker
 env:
   global:
-    - PINS="mirage-flow.2.0.0:. mirage-flow-combinators.2.0.0:. mirage-flow-unix.2.0.0:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
+    - PINS="mirage-flow.2.0.0:. mirage-flow-combinators.2.0.0:. mirage-flow-unix.2.0.0:."
+    - DISTRO="alpine"
   matrix:
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-combinators"
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-unix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="mirage-flow.2.0.0:. mirage-flow-combinators.2.0.0:. mirage-flow-unix:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
+    - PINS="mirage-flow:. mirage-flow-combinators:. mirage-flow-unix:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
   matrix:
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-combinators"
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-unix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="mirage-flow:. mirage-flow-combinators:. mirage-flow-unix:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
+    - PINS="mirage-flow.2.0.0:. mirage-flow-combinators.2.0.0:. mirage-flow-unix.2.0.0:. mirage-clock.3.0.0:git+https://github.com/hannesm/mirage-clock.git#easy"
   matrix:
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-combinators"
   - OCAML_VERSION=4.06 PACKAGE="mirage-flow-unix"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
-### v2.0.0
+### v2.0.0 (2019-10-23)
 
-* mirage-flow uses Lwt.t and Cstruct.t directly
-* mirage-flow-lwt was removed, combinators are now in mirage-flow-combinators
+* mirage-flow uses Lwt.t and Cstruct.t directly (#43 @hannesm)
+* mirage-flow-lwt was removed, combinators are now in mirage-flow-combinators (#43 @hannesm)
+* raise lower OCaml bound to 4.06.0 (#43 @hannesm)
 
 ### v1.6.0 (2019-04-24)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v2.0.0
+
+* mirage-flow uses Lwt.t and Cstruct.t directly
+* mirage-flow-lwt was removed, combinators are now in mirage-flow-combinators
+
 ### v1.6.0 (2019-04-24)
 
 * remove uses of `Result` (#40 @hannesm)
@@ -5,7 +10,7 @@
 * port build to dune from jbuilder (#41 @hannesm)
 
 ### v1.5.0 (2018-07-09)
-  
+
 * remove Result module, work with `-safe-string` and require cstruct >=3.2.0
 
 ### v1.4.0 (2017-06-23)

--- a/combinators/dune
+++ b/combinators/dune
@@ -1,0 +1,5 @@
+(library
+ (name mirage_flow_combinators)
+ (public_name mirage-flow-combinators)
+ (libraries lwt cstruct mirage-flow mirage-clock logs)
+ (wrapped false))

--- a/combinators/mirage_flow_combinators.ml
+++ b/combinators/mirage_flow_combinators.ml
@@ -18,26 +18,45 @@
 
 open Lwt.Infix
 
-let src = Logs.Src.create "mirage-flow-lwt"
+let src = Logs.Src.create "mirage-flow-combinators"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module type S = Mirage_flow.S
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
+module type CONCRETE =  Mirage_flow.S
+  with type error = [ `Msg of string ]
+   and type write_error = [ Mirage_flow.write_error | `Msg of string ]
 
-module type ABSTRACT = Mirage_flow.ABSTRACT
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
+module Concrete (S: Mirage_flow.S) = struct
+  type error = [`Msg of string]
+  type write_error = [ Mirage_flow.write_error | `Msg of string]
+  type flow = S.flow
 
-module type CONCRETE =  Mirage_flow.CONCRETE
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
+  let pp_error ppf = function
+    | `Msg s -> Fmt.string ppf s
 
-module Concrete (S: S) = Mirage_flow.Concrete(S)(Lwt)
+  let pp_write_error ppf = function
+    | #error as e -> pp_error ppf e
+    | `Closed     -> Mirage_flow.pp_write_error ppf `Closed
 
-module type SHUTDOWNABLE = Mirage_flow.SHUTDOWNABLE
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
+  let lift_read = function
+    | Ok x    -> Ok x
+    | Error e -> Error (`Msg (Fmt.strf "%a" S.pp_error e))
+
+  let lift_write = function
+    | Ok ()         -> Ok ()
+    | Error `Closed -> Error `Closed
+    | Error e       -> Error (`Msg (Fmt.strf "%a" S.pp_write_error e))
+
+  let read t = S.read t >|= lift_read
+  let write t b = S.write t b >|= lift_write
+  let writev t bs = S.writev t bs >|= lift_write
+  let close t = S.close t
+end
+
+module type SHUTDOWNABLE = sig
+  include Mirage_flow.S
+  val shutdown_write: flow -> unit Lwt.t
+  val shutdown_read: flow -> unit Lwt.t
+end
 
 type time = int64
 
@@ -64,7 +83,7 @@ let stats t =
     duration;
   }
 
-module Copy (Clock: Mirage_clock.MCLOCK) (A: S) (B: S) =
+module Copy (Clock: Mirage_clock.MCLOCK) (A: Mirage_flow.S) (B: Mirage_flow.S) =
 struct
 
   type error = [`A of A.error | `B of B.write_error]
@@ -73,20 +92,20 @@ struct
     | `A e -> A.pp_error ppf e
     | `B e -> B.pp_write_error ppf e
 
-  let start (clock:Clock.t) (a: A.flow) (b: B.flow) =
+  let start (a: A.flow) (b: B.flow) =
     let read_bytes = ref 0L in
     let read_ops = ref 0L in
     let write_bytes = ref 0L in
     let write_ops = ref 0L in
     let finish = ref None in
-    let start = Clock.elapsed_ns clock in
-    let rec loop c () =
+    let start = Clock.elapsed_ns () in
+    let rec loop () =
       A.read a >>= function
       | Error e ->
-        finish := Some (Clock.elapsed_ns c);
+        finish := Some (Clock.elapsed_ns ());
         Lwt.return (Error (`A e))
       | Ok `Eof ->
-        finish := Some (Clock.elapsed_ns c);
+        finish := Some (Clock.elapsed_ns ());
         Lwt.return (Ok ())
       | Ok (`Data buffer) ->
         read_ops := Int64.succ !read_ops;
@@ -96,9 +115,9 @@ struct
         | Ok () ->
           write_ops := Int64.succ !write_ops;
           write_bytes := Int64.(add !write_bytes (of_int @@ Cstruct.len buffer));
-          loop c ()
+          loop ()
         | Error e ->
-          finish := Some (Clock.elapsed_ns c);
+          finish := Some (Clock.elapsed_ns ());
           Lwt.return (Error (`B e))
     in
     {
@@ -108,14 +127,14 @@ struct
       write_ops;
       finish;
       start;
-      time = (fun () -> Clock.elapsed_ns clock);
-      t = loop clock ();
+      time = (fun () -> Clock.elapsed_ns ());
+      t = loop ();
     }
 
   let wait t = t.t
 
-  let copy clock ~src:a ~dst:b =
-    let t = start clock a b in
+  let copy ~src:a ~dst:b =
+    let t = start a b in
     wait t >|= function
     | Ok ()   -> Ok (stats t)
     | Error e -> Error e
@@ -141,9 +160,9 @@ struct
     | `A e -> Fmt.pf ppf "flow proxy a: %a" A_to_B.pp_error e
     | `B e -> Fmt.pf ppf "flow proxy b: %a" B_to_A.pp_error e
 
-  let proxy clock a b =
+  let proxy a b =
     let a2b =
-      let t = A_to_B.start clock a b in
+      let t = A_to_B.start a b in
       A_to_B.wait t >>= fun result ->
       A.shutdown_read a >>= fun () ->
       B.shutdown_write b >|= fun () ->
@@ -153,7 +172,7 @@ struct
       | Error e -> Error e
     in
     let b2a =
-      let t = B_to_A.start clock b a in
+      let t = B_to_A.start b a in
       B_to_A.wait t >>= fun result ->
       B.shutdown_read b >>= fun () ->
       A.shutdown_write a >|= fun () ->
@@ -175,9 +194,6 @@ end
 module F = struct
 
   let (>>=) = Lwt.bind
-
-  type 'a io = 'a Lwt.t
-  type buffer = Cstruct.t
 
   type refill = Cstruct.t -> int -> int -> int Lwt.t
 
@@ -319,8 +335,6 @@ module F = struct
 
 end
 
-type 'a io = 'a Lwt.t
-type buffer = Cstruct.t
 type error = [`Msg of string]
 type write_error = [ Mirage_flow.write_error | error ]
 let pp_error ppf (`Msg s) = Fmt.string ppf s
@@ -334,7 +348,7 @@ type flow =
 
 type t = flow
 
-let create (type a) (module M: S with type flow = a) t name =
+let create (type a) (module M: Mirage_flow.S with type flow = a) t name =
   let m = (module Concrete(M): CONCRETE with type flow = a) in
   Flow (name, m , t)
 

--- a/combinators/mirage_flow_combinators.ml
+++ b/combinators/mirage_flow_combinators.ml
@@ -198,7 +198,8 @@ module F = struct
   type refill = Cstruct.t -> int -> int -> int Lwt.t
 
   type error
-  let pp_error ppf (_:error) = Fmt.string ppf "Mirage_flow_lwt.Fun.error"
+  let pp_error ppf (_:error) =
+    Fmt.string ppf "Mirage_flow_combinators.F.error"
   type write_error = Mirage_flow.write_error
   let pp_write_error = Mirage_flow.pp_write_error
 

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,6 +1,0 @@
-(library
- (name mirage_flow_lwt)
- (public_name mirage-flow-lwt)
- (libraries lwt cstruct mirage-flow mirage-clock logs)
- (wrapped false)
- (flags :standard -safe-string))

--- a/mirage-flow-combinators.opam
+++ b/mirage-flow-combinators.opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "cstruct" {>= "4.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {= version}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-flow-combinators.opam
+++ b/mirage-flow-combinators.opam
@@ -7,14 +7,14 @@ homepage: "https://github.com/mirage/mirage-flow"
 doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "fmt"
-  "lwt"
+  "lwt" {>= "4.4.0"}
   "logs"
-  "cstruct" {>= "2.0.0"}
-  "mirage-clock" {>= "1.2.0"}
-  "mirage-flow" {>= "1.2.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-flow-unix.opam
+++ b/mirage-flow-unix.opam
@@ -7,15 +7,15 @@ homepage: "https://github.com/mirage/mirage-flow"
 doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "fmt"
   "logs"
-  "mirage-flow" {>= "1.2.0"}
-  "mirage-flow-lwt" {>= "1.2.0"}
-  "lwt"
+  "mirage-flow" {>= "2.0.0"}
+  "lwt" {>= "4.4.0"}
   "cstruct" {>= "3.2.0"}
   "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & >= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-flow-unix.opam
+++ b/mirage-flow-unix.opam
@@ -11,11 +11,11 @@ depends: [
   "dune" {>= "1.0"}
   "fmt"
   "logs"
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {= version}
   "lwt" {>= "4.4.0"}
-  "cstruct" {>= "3.2.0"}
+  "cstruct" {>= "4.0.0"}
   "alcotest" {with-test}
-  "mirage-flow-combinators" {with-test & >= "2.0.0"}
+  "mirage-flow-combinators" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-flow.opam
+++ b/mirage-flow.opam
@@ -7,10 +7,13 @@ homepage: "https://github.com/mirage/mirage-flow"
 doc: "https://mirage.github.io/mirage-flow/"
 bug-reports: "https://github.com/mirage/mirage-flow/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
   "fmt"
+  "lwt" {>= "4.4.0"}
 ]
+conflicts: [ "mirage-flow-lwt" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/mirage-flow.opam
+++ b/mirage-flow.opam
@@ -13,7 +13,6 @@ depends: [
   "fmt"
   "lwt" {>= "4.4.0"}
 ]
-conflicts: [ "mirage-flow-lwt" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,5 @@
 (library
  (name mirage_flow)
  (public_name mirage-flow)
- (libraries fmt)
- (wrapped false)
- (flags :standard -safe-string))
+ (libraries fmt lwt cstruct)
+ (wrapped false))

--- a/src/mirage_flow.ml
+++ b/src/mirage_flow.ml
@@ -27,64 +27,16 @@ let pp_or_eof d ppf = function
   | `Data a -> d ppf a
   | `Eof    -> Fmt.string ppf "End-of-file"
 
-module type ABSTRACT = sig
-  type +'a io
+module type S = sig
   type error
   val pp_error: error Fmt.t
-  type write_error
+  type nonrec write_error = private [> write_error ]
   val pp_write_error: write_error Fmt.t
-  type buffer
   type flow
-  val read: flow -> (buffer or_eof, error) result io
-  val write: flow -> buffer -> (unit, write_error) result io
-  val writev: flow -> buffer list -> (unit, write_error) result io
-  val close: flow -> unit io
-end
-
-module type S = ABSTRACT with type write_error = private [> write_error]
-  [@@ocaml.warning "-34"]
-
-module type CONCRETE = ABSTRACT
-  with type error = [`Msg of string]
-   and type write_error = [write_error | `Msg of string]
-
-module Concrete (S: S) (IO: sig
-       type 'a t = 'a S.io
-       val map: ('a -> 'b) -> 'a t -> 'b t
-  end) =
-struct
-  type 'a io = 'a S.io
-  type error = [`Msg of string]
-  type write_error = [ `Closed | `Msg of string]
-  type buffer = S.buffer
-  type flow = S.flow
-
-  let pp_error ppf = function
-    | `Msg s -> Fmt.string ppf s
-
-  let pp_write_error ppf = function
-    | #error as e -> pp_error ppf e
-    | `Closed     -> pp_write_error ppf `Closed
-
-  let lift_read = function
-    | Ok x    -> Ok x
-    | Error e -> Error (`Msg (Fmt.strf "%a" S.pp_error e))
-
-  let lift_write = function
-    | Ok ()         -> Ok ()
-    | Error `Closed -> Error `Closed
-    | Error e       -> Error (`Msg (Fmt.strf "%a" S.pp_write_error e))
-
-  let read t = IO.map lift_read (S.read t)
-  let write t b = IO.map lift_write (S.write t b)
-  let writev t bs = IO.map lift_write (S.writev t bs)
-  let close t = S.close t
-end
-
-module type SHUTDOWNABLE = sig
-  include S
-  val shutdown_write: flow -> unit io
-  val shutdown_read: flow -> unit io
+  val read: flow -> (Cstruct.t or_eof, error) result Lwt.t
+  val write: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
+  val writev: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
+  val close: flow -> unit Lwt.t
 end
 
 type stats = {

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test)
- (libraries mirage-flow-unix alcotest))
+ (libraries mirage-flow-combinators mirage-flow-unix alcotest))
 
 (alias
  (name runtest)

--- a/test/test.ml
+++ b/test/test.ml
@@ -15,7 +15,7 @@
  *)
 
 open Lwt.Infix
-open Mirage_flow_lwt
+open Mirage_flow_combinators
 
 let pp_buf ppf buf = Fmt.string ppf (Cstruct.to_string buf)
 let eq_buf b1 b2 = Cstruct.to_string b1 = Cstruct.to_string b2

--- a/unix/dune
+++ b/unix/dune
@@ -1,6 +1,5 @@
 (library
  (name mirage_flow_unix)
  (public_name mirage-flow-unix)
- (libraries mirage-flow-lwt lwt.unix logs)
- (wrapped false)
- (flags :standard -safe-string))
+ (libraries mirage-flow lwt.unix logs)
+ (wrapped false))

--- a/unix/mirage_flow_unix.ml
+++ b/unix/mirage_flow_unix.ml
@@ -19,7 +19,7 @@ open Lwt.Infix
 let src = Logs.Src.create "mirage-flow-unix"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (F: Mirage_flow_lwt.S) = struct
+module Make (F: Mirage_flow.S) = struct
 
   let reader t =
     let frag = ref (Cstruct.create 0) in
@@ -66,8 +66,6 @@ end
 
 module Fd = struct
 
-  type 'a io = 'a Lwt.t
-  type buffer = Cstruct.t
   type error = [`Msg of string]
   type write_error = [ Mirage_flow.write_error | error ]
 

--- a/unix/mirage_flow_unix.mli
+++ b/unix/mirage_flow_unix.mli
@@ -16,7 +16,7 @@
 
 (** Conversion from mirage flows to Lwt_io channels. *)
 
-module Make (F: Mirage_flow_lwt.S): sig
+module Make (F: Mirage_flow.S): sig
 
   val ic: ?buffer_size:int -> ?close:bool -> F.flow -> Lwt_io.input_channel
   (** Build an [Lwt_io] input channel from a mirage flow. If [close]
@@ -30,4 +30,4 @@ module Make (F: Mirage_flow_lwt.S): sig
 
 end
 
-module Fd: Mirage_flow_lwt.S with type flow = Lwt_unix.file_descr
+module Fd: Mirage_flow.S with type flow = Lwt_unix.file_descr


### PR DESCRIPTION
as discussed in mirage/mirage#1004, this:
- retires mirage-flow-lwt
- moves combinators into mirage-flow-combinators
- specialises mirage-flow to Lwt.t and Cstruct.t
- bumps lower ocaml bound to 4.06.0