### PR TITLE
Add Mirage_flow.shutdown: flow -> [ read | write | read_write ] -> unit Lwt.t

### DIFF
--- a/combinators/mirage_flow_combinators.mli
+++ b/combinators/mirage_flow_combinators.mli
@@ -32,20 +32,6 @@ module type CONCRETE =  Mirage_flow.S
     errors into concrete error types. *)
 module Concrete (S: Mirage_flow.S): CONCRETE with type flow = S.flow
 
-(** {1 Shutdownable flows} *)
-module type SHUTDOWNABLE = sig
-  include Mirage_flow.S
-
-  val shutdown_write: flow -> unit Lwt.t
-  (** Close the [write] direction of the flow, flushing any buffered
-      data and causing future calls to [read] by the peer to return
-      [`Eof]. *)
-
-  val shutdown_read: flow -> unit Lwt.t
-  (** Close the [read] direction of the flow, such that future calls
-      to [write] by the peer will return [`Eof] *)
-end
-
 module Copy (Clock: Mirage_clock.MCLOCK) (A: Mirage_flow.S) (B: Mirage_flow.S): sig
 
   type error = [`A of A.error | `B of B.write_error]
@@ -62,7 +48,7 @@ module Copy (Clock: Mirage_clock.MCLOCK) (A: Mirage_flow.S) (B: Mirage_flow.S): 
 
 end
 
-module Proxy (Clock: Mirage_clock.MCLOCK) (A: SHUTDOWNABLE) (B: SHUTDOWNABLE):
+module Proxy (Clock: Mirage_clock.MCLOCK) (A: Mirage_flow.S) (B: Mirage_flow.S):
 sig
 
   type error

--- a/src/mirage_flow.ml
+++ b/src/mirage_flow.ml
@@ -36,6 +36,7 @@ module type S = sig
   val read: flow -> (Cstruct.t or_eof, error) result Lwt.t
   val write: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
   val writev: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
+  val shutdown : flow -> [ `read | `write | `read_write ] -> unit Lwt.t
   val close: flow -> unit Lwt.t
 end
 

--- a/src/mirage_flow.mli
+++ b/src/mirage_flow.mli
@@ -83,6 +83,13 @@ module type S = sig
       connection is now closed and therefore the data could not be
       written.  Other errors are possible. *)
 
+  val shutdown : flow -> [ `read | `write | `read_write ] -> unit Lwt.t
+  (** [shutdown flow mode] shuts down the [flow] for the specific [mode]:
+      A flow which is [shutdown `read] (or [`read_write] will never be [read]
+      again (future calls will return [`Eof]); a flow which is [shutdown `write]
+      (or [`read_write]) flushes all pending writes and signals the remote
+      endpoint there won't be any future [write]. In TCP, a FIN is sent. *)
+
   val close: flow -> unit Lwt.t
   (** [close flow] flushes all pending writes and signals the remote
       endpoint that there will be no future writes. Once the remote endpoint

--- a/unix/mirage_flow_unix.ml
+++ b/unix/mirage_flow_unix.ml
@@ -122,6 +122,14 @@ module Fd = struct
 
   let close t = Lwt_unix.close t
 
+  let shutdown t mode =
+    let cmd = Lwt_unix.(match mode with
+        | `read -> SHUTDOWN_RECEIVE
+        | `write -> SHUTDOWN_SEND
+        | `read_write -> SHUTDOWN_ALL)
+    in
+    Lwt.return (Lwt_unix.shutdown t cmd)
+
   let writev t bs =
     Lwt.catch (fun () ->
         Lwt_list.iter_s (fun b -> write_all t (Cstruct.to_bytes b)) bs


### PR DESCRIPTION
Also removes SHUTDOWNABLE signature (#17)
Superseeds #18 (which proposed disconnect)

This reason for this is multi-fold, a recent issue is about HTTP/2 and how to shutdown the write direction only. Also, this interface is present in Unix.

//cc @djs55 (who mentioned that `` shutdown `read `` is not used much: I guess we could use that to save some space in the TCP stack (the receive buffer no longer needs to be present)

//cc @dinosaure who encountered the HTTP2 issue

//cc @talex5 who in https://github.com/mirleft/ocaml-tls/pull/451 mentioned the lack of such functionality (and tls_lwt is close to the Mirage_flow.S signature, tls_mirage is implementing it)

And once more //cc @djs55 who has been proposing this since quite some time. I hope this PR suits you well (I've not much experience with Mirage_flow_unix and Mirage_flow_combinators, and would be keen to know whether the changes are reasonable).

If we can agree on this change, we can quickly revise the ecosystem to conform with the new interface. It'd be interesting whether we should as well revise `read` (as poposed in #46) to (if I understand correctly) get the buffer passed instead of allocating the underlying buffer (and thus clean up ownership methodology) //cc @haesbaert who may be interested as well.